### PR TITLE
pass `categories` value as an argument to the exporter

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagespeed-exporter
 description: Pagespeed Exporter
 type: application
-version: 1.1.2
-appVersion: 2.1.2
+version: 1.1.3
+appVersion: 3.0.2
 icon: https://www.gstatic.com/images/icons/material/product/2x/pagespeed_64dp.png
 sources:
   - https://github.com/softonic/pagespeed-exporter-chart

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -30,11 +30,11 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-          - name: GOOGLE_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.exporter.googleapikey.secretname }}
-                key: apikey
+            - name: GOOGLE_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.exporter.googleapikey.secretname }}
+                  key: apikey
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -44,6 +44,9 @@ spec:
             - "-parallel={{ .Values.exporter.parallel }}"
           {{- range $_, $target := .Values.exporter.targets }}
             - "-t={{ $target }}"
+          {{- end }}
+          {{- with .Values.exporter.categories }}
+            - "-categories={{ . }}"
           {{- end }}
           {{- if .Values.exporter.pushGatewayUrl }}
             - "-pushGatewayUrl={{ .Values.exporter.pushGatewayUrl }}"

--- a/values.yaml
+++ b/values.yaml
@@ -72,6 +72,8 @@ exporter:
   pushGatewayUrl: ""
   targets: []
   parallel: false
+  # default categories if left empty
+  categories: ""
 
 # Enable this if you're using https://github.com/coreos/prometheus-operator
 serviceMonitor:


### PR DESCRIPTION
According to [exporter's configuration](https://github.com/foomo/pagespeed_exporter/tree/v.3.0.3#exporter-configuration) documentation, we can control which categories we are interested in. If left blank, a set of default categories is used (all of them actually)

This PR makes it possible to specify which categories to query, by using an `exporter.categories` value.

[pending testing]

Closes #2 