### PR TITLE
Use parentheses

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pagespeed-exporter
 description: Pagespeed Exporter
 type: application
-version: 1.1.3
+version: 1.1.4
 appVersion: 2.1.2
 icon: https://www.gstatic.com/images/icons/material/product/2x/pagespeed_64dp.png
 sources:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "-api-key=$GOOGLE_APIKEY"
+            - "-api-key=$(GOOGLE_APIKEY)"
             - "-parallel={{ .Values.exporter.parallel }}"
           {{- range $_, $target := .Values.exporter.targets }}
             - "-t={{ $target }}"


### PR DESCRIPTION
https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#use-environment-variables-to-define-arguments

Use parentheses as described in the documentation. Without this, the variable will not be expanded correctly. 